### PR TITLE
feat: click search result to scroll to message in full view

### DIFF
--- a/bin/claude-sessions-export
+++ b/bin/claude-sessions-export
@@ -572,6 +572,11 @@ cat > "$output" << HEADER
 
     .message.has-match {
       border-color: var(--accent-amber);
+      cursor: pointer;
+    }
+
+    .message.has-match:hover {
+      background: var(--bg-hover);
     }
 
     .message.hidden-by-search {
@@ -831,16 +836,16 @@ cat >> "$output" << 'FOOTER'
       const timeHtml = timeStr ? `<span class="timestamp">${timeStr}</span>` : '';
 
       if (msg.type === 'summary') {
-        container.innerHTML += `<div class="summary" style="animation-delay: ${delay}ms">${msg.text}</div>`;
+        container.innerHTML += `<div class="summary" id="msg-${index}" style="animation-delay: ${delay}ms">${msg.text}</div>`;
       } else if (msg.type === 'slashcommand') {
         container.innerHTML += `
-          <div class="message slashcommand" style="animation-delay: ${delay}ms">
+          <div class="message slashcommand" id="msg-${index}" style="animation-delay: ${delay}ms">
             <div class="role">Slash Command: ${msg.command} ${timeHtml}</div>
             <div class="content">${marked.parse(msg.text)}</div>
           </div>`;
       } else if (msg.type === 'user') {
         container.innerHTML += `
-          <div class="message user" style="animation-delay: ${delay}ms">
+          <div class="message user" id="msg-${index}" style="animation-delay: ${delay}ms">
             <div class="role">You ${timeHtml}</div>
             <div class="content">${marked.parse(msg.text)}</div>
           </div>`;
@@ -855,7 +860,7 @@ cat >> "$output" << 'FOOTER'
           }).join('');
         }
         container.innerHTML += `
-          <div class="message assistant" style="animation-delay: ${delay}ms">
+          <div class="message assistant" id="msg-${index}" style="animation-delay: ${delay}ms">
             <div class="role">Claude ${timeHtml}</div>
             <div class="content">${marked.parse(msg.text)}${toolsHtml}</div>
           </div>`;
@@ -917,7 +922,7 @@ cat >> "$output" << 'FOOTER'
       }
     }
 
-    function clearSearch() {
+    function clearSearch(scrollToId = null) {
       document.getElementById('searchInput').value = '';
       const allMessages = document.querySelectorAll('.message');
       allMessages.forEach((msg, i) => {
@@ -926,7 +931,32 @@ cat >> "$output" << 'FOOTER'
         msg.classList.remove('has-match');
       });
       document.getElementById('searchMeta').style.display = 'none';
+
+      // If a scrollToId was provided, scroll to that message
+      if (scrollToId) {
+        const target = document.getElementById(scrollToId);
+        if (target) {
+          // Small delay to let DOM update
+          setTimeout(() => {
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // Brief highlight effect
+            target.style.boxShadow = '0 0 0 2px var(--accent-amber)';
+            setTimeout(() => { target.style.boxShadow = ''; }, 1500);
+          }, 50);
+        }
+      }
     }
+
+    // Click handler for search results - clears search and scrolls to clicked message
+    document.getElementById('messages').addEventListener('click', (e) => {
+      const msg = e.target.closest('.message');
+      if (msg && msg.classList.contains('has-match')) {
+        const msgId = msg.id;
+        if (msgId) {
+          clearSearch(msgId);
+        }
+      }
+    });
 
     // Event listeners
     let searchTimeout;


### PR DESCRIPTION
## Summary

Improves the search UX in HTML exports by allowing users to click on a search result to view it in context.

### Behavior

1. User searches for something (e.g., "workflow")
2. Non-matching messages are hidden, matching ones highlighted
3. **User clicks on a search result**
4. Search clears, all messages become visible again
5. Page smoothly scrolls to the clicked message
6. Message briefly glows amber (1.5s) to help locate it

### Visual feedback

- Matched messages show pointer cursor
- Hover state with background change indicates clickability

## Test plan

- [ ] Export a session and search for a term
- [ ] Click on a search result
- [ ] Verify search clears and page scrolls to that message
- [ ] Verify amber highlight appears briefly