### PR TITLE
feat: add command to open session files in VS Code with formatting

### DIFF
--- a/cmd/sessions/main.go
+++ b/cmd/sessions/main.go
@@ -443,15 +443,9 @@ func formatJSON(inputPath string, shortID string) (string, error) {
 	dataDir := filepath.Dir(filepath.Dir(sessionDir))
 
 	messageDir := filepath.Join(dataDir, "message", sessionID)
-	fmt.Fprintf(os.Stderr, "DEBUG: inputPath=%s\n", inputPath)
-	fmt.Fprintf(os.Stderr, "DEBUG: sessionID=%s\n", sessionID)
-	fmt.Fprintf(os.Stderr, "DEBUG: sessionDir=%s\n", sessionDir)
-	fmt.Fprintf(os.Stderr, "DEBUG: dataDir=%s\n", dataDir)
-	fmt.Fprintf(os.Stderr, "DEBUG: messageDir=%s\n", messageDir)
 
 	var messages []interface{}
 	if entries, err := os.ReadDir(messageDir); err == nil {
-		fmt.Fprintf(os.Stderr, "DEBUG: found %d message files\n", len(entries))
 		for _, entry := range entries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 				continue
@@ -491,8 +485,6 @@ func formatJSON(inputPath string, shortID string) (string, error) {
 			msg["parts"] = parts
 			messages = append(messages, msg)
 		}
-	} else {
-		fmt.Fprintf(os.Stderr, "DEBUG: error reading message dir: %v\n", err)
 	}
 
 	session["messages"] = messages

--- a/cmd/sessions/main.go
+++ b/cmd/sessions/main.go
@@ -435,11 +435,18 @@ func formatJSON(inputPath string, shortID string) (string, error) {
 	}
 
 	sessionDir := filepath.Dir(inputPath)
-	dataDir := filepath.Join(sessionDir, "..", "..", "..")
+	dataDir := filepath.Dir(filepath.Dir(sessionDir))
 
 	messageDir := filepath.Join(dataDir, "message", sessionID)
+	fmt.Fprintf(os.Stderr, "DEBUG: inputPath=%s\n", inputPath)
+	fmt.Fprintf(os.Stderr, "DEBUG: sessionID=%s\n", sessionID)
+	fmt.Fprintf(os.Stderr, "DEBUG: sessionDir=%s\n", sessionDir)
+	fmt.Fprintf(os.Stderr, "DEBUG: dataDir=%s\n", dataDir)
+	fmt.Fprintf(os.Stderr, "DEBUG: messageDir=%s\n", messageDir)
+
 	var messages []interface{}
 	if entries, err := os.ReadDir(messageDir); err == nil {
+		fmt.Fprintf(os.Stderr, "DEBUG: found %d message files\n", len(entries))
 		for _, entry := range entries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 				continue
@@ -479,6 +486,8 @@ func formatJSON(inputPath string, shortID string) (string, error) {
 			msg["parts"] = parts
 			messages = append(messages, msg)
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "DEBUG: error reading message dir: %v\n", err)
 	}
 
 	session["messages"] = messages

--- a/cmd/sessions/main.go
+++ b/cmd/sessions/main.go
@@ -368,6 +368,11 @@ func runOpen(adapter adapters.Adapter, sid string) error {
 		return fmt.Errorf("failed to open in VS Code: %w", err)
 	}
 
+	// Reap child process in background to avoid zombie processes
+	go func() {
+		_ = cmd.Wait()
+	}()
+
 	fmt.Printf("Opening formatted session in VS Code: %s\n", formattedPath)
 	return nil
 }

--- a/cmd/sessions/main_test.go
+++ b/cmd/sessions/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFormatJSONL(t *testing.T) {
+	// Create temp input file with JSONL content
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "test.jsonl")
+
+	input := `{"type":"message","content":"hello"}
+{"type":"response","content":"world"}
+`
+	if err := os.WriteFile(inputPath, []byte(input), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	outputPath, err := formatJSONL(inputPath, "testid12")
+	if err != nil {
+		t.Fatalf("formatJSONL failed: %v", err)
+	}
+
+	// Verify output file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Fatalf("output file was not created: %s", outputPath)
+	}
+
+	// Read and verify content is pretty-printed
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	// Check that output contains indentation (pretty-printed)
+	if !strings.Contains(string(content), "  ") {
+		t.Error("output should be pretty-printed with indentation")
+	}
+
+	// Check that both objects are present
+	if !strings.Contains(string(content), `"type": "message"`) {
+		t.Error("output should contain first JSON object")
+	}
+	if !strings.Contains(string(content), `"type": "response"`) {
+		t.Error("output should contain second JSON object")
+	}
+
+	// Cleanup
+	os.Remove(outputPath)
+}
+
+func TestFormatJSONL_EmptyLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "test.jsonl")
+
+	// Input with empty lines that should be skipped
+	input := `{"type":"message"}
+
+{"type":"response"}
+`
+	if err := os.WriteFile(inputPath, []byte(input), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	outputPath, err := formatJSONL(inputPath, "testid34")
+	if err != nil {
+		t.Fatalf("formatJSONL failed: %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	// Should have 2 JSON objects separated by double newline
+	parts := strings.Split(strings.TrimSpace(string(content)), "\n\n")
+	if len(parts) != 2 {
+		t.Errorf("expected 2 JSON objects, got %d", len(parts))
+	}
+
+	os.Remove(outputPath)
+}
+
+func TestFormatJSONL_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "test.jsonl")
+
+	// Input with invalid JSON line - should be preserved as-is
+	input := `{"type":"valid"}
+not valid json
+{"type":"alsovalid"}
+`
+	if err := os.WriteFile(inputPath, []byte(input), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	outputPath, err := formatJSONL(inputPath, "testid56")
+	if err != nil {
+		t.Fatalf("formatJSONL failed: %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	// Invalid JSON line should be preserved
+	if !strings.Contains(string(content), "not valid json") {
+		t.Error("invalid JSON line should be preserved as-is")
+	}
+
+	os.Remove(outputPath)
+}
+
+func TestFormatJSONL_FileNotFound(t *testing.T) {
+	_, err := formatJSONL("/nonexistent/path/file.jsonl", "testid78")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `open <id>` command to open session files in VS Code
- Add `Ctrl-E` keyboard shortcut in TUI for the same functionality
- Formats session files before opening:
  - Claude: pretty-prints JSONL with 2-space indentation
  - OpenCode: uses `jq` to format JSON
- Writes formatted files to `/tmp` to preserve originals

## Changes
- New `runOpen` function handles both adapters
- New `formatJSONL` function for Claude sessions with 10MB buffer for large lines
- New `formatJSON` function for OpenCode sessions using jq
- Added `ActionOpen` to TUI action types
- Updated help text with new command and shortcut